### PR TITLE
Clear timer when debouncing

### DIFF
--- a/Timer.js
+++ b/Timer.js
@@ -184,9 +184,8 @@ define(function(require, exports, module) {
                 }
             };
 
-            if (!timeout) {
-                timeout = setTimeout(fn, wait);
-            }
+            clear(timeout);
+            timeout = setTimeout(fn, wait);
 
             return result;
         };


### PR DESCRIPTION
This makes Timer.debounce behave like _.debounce where the function is not called until {wait} milliseconds after the last time it was invoked.

http://underscorejs.org/#debounce
